### PR TITLE
Add support for nodejs cached data

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1792,7 +1792,7 @@ var AMDLoader;
                         callback();
                     }
                     else {
-                        var cachedDataPath_1 = _this._path.join(opts.nodeCachedDataDir, scriptSrc.replace(/\\|\//g, '') + '.code');
+                        var cachedDataPath_1 = _this._getCachedDataPath(opts.nodeCachedDataDir, scriptSrc);
                         _this._fs.readFile(cachedDataPath_1, function (err, data) {
                             // create script options
                             var scriptOptions = {
@@ -1840,6 +1840,11 @@ var AMDLoader;
                     }
                 });
             }
+        };
+        NodeScriptLoader.prototype._getCachedDataPath = function (baseDir, filename) {
+            var hash = this._crypto.createHash('md5').update(filename, 'utf8').digest('hex');
+            var basename = this._path.basename(filename).replace(/\.js$/, '');
+            return this._path.join(baseDir, hash + "-" + basename + ".code");
         };
         NodeScriptLoader._runSoon = function (callback, minTimeout) {
             var timeout = minTimeout + Math.ceil(Math.random() * minTimeout);

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -2251,6 +2251,7 @@ module AMDLoader {
 	interface INodePath {
 		dirname(filename:string): string;
 		normalize(filename: string):string;
+		basename(filename: string): string;
 		join(...parts: string[]): string;
 	}
 
@@ -2373,7 +2374,7 @@ module AMDLoader {
 
 					} else {
 
-						const cachedDataPath = this._path.join(opts.nodeCachedDataDir, scriptSrc.replace(/\\|\//g, '') + '.code');
+						const cachedDataPath = this._getCachedDataPath(opts.nodeCachedDataDir, scriptSrc);
 
 						this._fs.readFile(cachedDataPath, (err, data) => {
 
@@ -2429,6 +2430,12 @@ module AMDLoader {
 					}
 				});
 			}
+		}
+
+		private _getCachedDataPath(baseDir: string, filename: string): string {
+			const hash = this._crypto.createHash('md5').update(filename, 'utf8').digest('hex');
+			const basename = this._path.basename(filename).replace(/\.js$/, '');
+			return this._path.join(baseDir, `${hash}-${basename}.code`);
 		}
 
 		private static _runSoon(callback: Function, minTimeout: number): void {

--- a/tests/node-specific/cached-data-create/_test.js
+++ b/tests/node-specific/cached-data-create/_test.js
@@ -4,7 +4,6 @@ var loader = require('../_loader');
 var control = require('../_control');
 
 var nodeCachedDataDir = path.join(__dirname, 'cache-dir');
-var aFile = path.join(__dirname, 'a.js');
 
 loader.config({
 	nodeRequire: require,
@@ -18,13 +17,15 @@ loader(['a'], function (a) {
 
 	setTimeout(() => {
 
-		var cachePath = path.join(nodeCachedDataDir, aFile.replace(/\\|\//g, '') + '.code');
-		if (fs.existsSync(cachePath)) {
+		const files = fs.readdirSync(nodeCachedDataDir).filter(p => /\.code$/.test(p));
+		if (files.length === 1) {
 			control.ok();
 		} else {
-			control.err('Expected file: ' + cachePath);
+			control.err('Unexpected .code-files' + files.join(', '));
 		}
-		fs.unlinkSync(cachePath);
+		for (const f of files) {
+			fs.unlinkSync(path.join(nodeCachedDataDir, f));
+		}
 
 	}, 100);
 });

--- a/tests/node-specific/cached-data-create/_test.js
+++ b/tests/node-specific/cached-data-create/_test.js
@@ -1,0 +1,30 @@
+var fs = require('fs');
+var path = require('path');
+var loader = require('../_loader');
+var control = require('../_control');
+
+var nodeCachedDataDir = path.join(__dirname, 'cache-dir');
+var aFile = path.join(__dirname, 'a.js');
+
+loader.config({
+	nodeRequire: require,
+	nodeMain: module.filename,
+	nodeCachedDataDir,
+	nodeCachedDataWriteDelay: 0
+});
+
+
+loader(['a'], function (a) {
+
+	setTimeout(() => {
+
+		var cachePath = path.join(nodeCachedDataDir, aFile.replace(/\\|\//g, '') + '.code');
+		if (fs.existsSync(cachePath)) {
+			control.ok();
+		} else {
+			control.err('Expected file: ' + cachePath);
+		}
+		fs.unlinkSync(cachePath);
+
+	}, 100);
+});

--- a/tests/node-specific/cached-data-create/a.js
+++ b/tests/node-specific/cached-data-create/a.js
@@ -1,0 +1,8 @@
+
+'use strict';
+
+define(function() {
+	return function() {
+		console.log('hello world');
+	};
+});


### PR DESCRIPTION
This PR adds support for cached data such that parsing scripts can happen faster. See: http://v8project.blogspot.co.uk/2015/07/code-caching.html and https://nodejs.org/api/vm.html#vm_class_vm_script