### PR TITLE
accept options in require.resolve

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -741,8 +741,8 @@ var AMDLoader;
                         // nothing
                     }
                 };
-                require.resolve = function resolve(request) {
-                    return Module._resolveFilename(request, mod);
+                require.resolve = function resolve(request, opts) {
+                    return Module._resolveFilename(request, mod, false, opts);
                 };
                 require.main = process.mainModule;
                 require.extensions = Module._extensions;


### PR DESCRIPTION
This aligns VSCode's facade API with the signature provided by Node.js https://nodejs.org/api/modules.html#modules_require_resolve_request_options