### PR TITLE
fix: self.eval() need a string on Chrome 86

### DIFF
--- a/src/core/scriptLoader.ts
+++ b/src/core/scriptLoader.ts
@@ -183,7 +183,7 @@ namespace AMDLoader {
 					text = `${text}\n//# sourceURL=${scriptSrc}`;
 					const func = (
 						trustedTypesPolicy
-							? self.eval(trustedTypesPolicy.createScript('', text))
+							? self.eval(trustedTypesPolicy.createScript('', text).toString())
 							: new Function(text)
 					);
 					func.call(self);

--- a/src/loader.js
+++ b/src/loader.js
@@ -698,7 +698,7 @@ var AMDLoader;
                 }).then(function (text) {
                     text = text + "\n//# sourceURL=" + scriptSrc;
                     var func = (trustedTypesPolicy
-                        ? self.eval(trustedTypesPolicy.createScript('', text))
+                        ? self.eval(trustedTypesPolicy.createScript('', text).toString())
                         : new Function(text));
                     func.call(self);
                     callback();


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode/issues/124199