### PR TITLE
Remove unused fallback code path

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -51,13 +51,7 @@ var CSSLoaderPlugin;
         BrowserCSSLoader.prototype._insertLinkNode = function (linkNode) {
             this._pendingLoads++;
             var head = document.head || document.getElementsByTagName('head')[0];
-            var other = head.getElementsByTagName('link') || head.getElementsByTagName('script');
-            if (other.length > 0) {
-                head.insertBefore(linkNode, other[other.length - 1]);
-            }
-            else {
-                head.appendChild(linkNode);
-            }
+            head.appendChild(linkNode);
         };
         BrowserCSSLoader.prototype.createLinkTag = function (name, cssUrl, externalCallback, externalErrorback) {
             var _this = this;

--- a/src/css.ts
+++ b/src/css.ts
@@ -64,7 +64,7 @@ module CSSLoaderPlugin {
 		public _insertLinkNode(linkNode: HTMLLinkElement): void {
 			this._pendingLoads++;
 			var head = document.head || document.getElementsByTagName('head')[0];
-			var other: HTMLCollectionOf<HTMLElement> = head.getElementsByTagName('link') || head.getElementsByTagName('script');
+			var other: HTMLCollectionOf<HTMLElement> = head.getElementsByTagName('link');
 			if (other.length > 0) {
 				head.insertBefore(linkNode, other[other.length - 1]);
 			} else {

--- a/src/css.ts
+++ b/src/css.ts
@@ -64,12 +64,7 @@ module CSSLoaderPlugin {
 		public _insertLinkNode(linkNode: HTMLLinkElement): void {
 			this._pendingLoads++;
 			var head = document.head || document.getElementsByTagName('head')[0];
-			var other: HTMLCollectionOf<HTMLElement> = head.getElementsByTagName('link');
-			if (other.length > 0) {
-				head.insertBefore(linkNode, other[other.length - 1]);
-			} else {
-				head.appendChild(linkNode);
-			}
+			head.appendChild(linkNode);
 		}
 
 		public createLinkTag(name: string, cssUrl: string, externalCallback: () => void, externalErrorback: (err: any) => void): HTMLLinkElement {


### PR DESCRIPTION
`getElementsByTagName` always return an `HTMLCollection`. So either this is not needed or the logic should fallback when the list of link elements is empty. I don't know what was the intention behind this so I've decided to just drop this since it's not working either way so most likely the other proposed solution is not needed by anyone.