### PR TITLE
Throw more detailed error when compilation fails

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -839,7 +839,12 @@ var AMDLoader;
                 catch (_e) {
                     recorder.record(61 /* CachedDataMissed */, cachedDataPath);
                 }
-                var script = new that._vm.Script(scriptSource, options);
+                var script;
+                try {
+                    script = new that._vm.Script(scriptSource, options);
+                } catch (err) {
+                    throw new Error(`Error compiling ${filename}. ${err}`);  
+                }
                 var compileWrapper = script.runInThisContext(options);
                 // run script
                 var dirname = that._path.dirname(filename);
@@ -902,7 +907,12 @@ var AMDLoader;
         NodeScriptLoader.prototype._createAndEvalScript = function (moduleManager, contents, options, callback, errorback) {
             var recorder = moduleManager.getRecorder();
             recorder.record(31 /* NodeBeginEvaluatingScript */, options.filename);
-            var script = new this._vm.Script(contents, options);
+            var script;
+            try {
+                script = new this._vm.Script(contents, options);
+            } catch (err) {
+                throw new Error(`Error compiling ${options.filename}. ${err}`);  
+            }
             var ret = script.runInThisContext(options);
             var globalDefineFunc = moduleManager.getGlobalAMDDefineFunc();
             var receivedDefineCall = false;


### PR DESCRIPTION
Currently the error only shows as something like this

`Uncaught SyntaxError: Unexpected token '??'`

which makes it difficult to track down which file is failing. 

New error : 

`Uncaught Error: Error compiling file:///.../vs/workbench/browser/parts/editor/editorGroupView.js. SyntaxError: Unex
pected token '??'`