### PR TITLE
Add extension esm support

### DIFF
--- a/src/core/scriptLoader.ts
+++ b/src/core/scriptLoader.ts
@@ -271,6 +271,7 @@ namespace AMDLoader {
 	interface INodeVMScriptOptions {
 		filename: string;
 		cachedData?: Buffer;
+		importModuleDynamically?: (specifier: string) => Promise<any>;
 	}
 
 	interface INodeVMScript {
@@ -452,7 +453,10 @@ namespace AMDLoader {
 					}
 
 					scriptSource = nodeInstrumenter(scriptSource, normalizedScriptSrc);
-					const scriptOpts: INodeVMScriptOptions = { filename: vmScriptPathOrUri, cachedData };
+					const scriptOpts: INodeVMScriptOptions = { filename: vmScriptPathOrUri, cachedData, importModuleDynamically: (specifier) => {
+						// @ts-ignore since dynamic imports require a module type to be set. Setting the AMD module type, however, is incompatible with the test suite
+							return import(specifier);
+					} };
 					const script = this._createAndEvalScript(moduleManager, scriptSource, scriptOpts, callback, errorback);
 
 					this._handleCachedData(script, scriptSource, cachedDataPath!, wantsCachedData && !cachedData, moduleManager);


### PR DESCRIPTION
Currently, it is impossible to import ESM modules in a vscode extension as those require dynamic imports. This PR introduces the possibility of using dynamic imports in vscode. I'm looking forward to your feedback!

https://nodejs.org/api/vm.html#when-importmoduledynamically-is-a-function
https://github.com/microsoft/vscode-loader/issues/36